### PR TITLE
Update driver name for compatibility with xone

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -2608,7 +2608,7 @@ static int xpad_resume(struct usb_interface *intf)
 }
 
 static struct usb_driver xpad_driver = {
-	.name		= "xpad",
+	.name		= "xpad-noone",
 	.probe		= xpad_probe,
 	.disconnect	= xpad_disconnect,
 	.suspend	= xpad_suspend,


### PR DESCRIPTION
This will ensure the driver will load even with xpad blacklisted

<!--
If you are adding support for a new generic xpad controller it is sufficient
to update the xpad_table[] array.
The type will be auto-detected in xpad_probe().
Updating the xpad_device[] array is only needed if the controller requires
additional flags like DANCEPAD_MAP_CONFIG to work.

If you are updating any of the above tables, make sure you keep the sorted!

# Attribution

To get attribution for your work when this goes upstream, make sure to add
the following line at the end of YOUR COMMIT MESSAGE:

Signed-off-by: Random J Developer <random@developer.example.org>

You must use real name and a real email address as per:
https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin

If you skip this line, your commit will be sent upstream anonymously.
 -->