### PR TITLE
add exception for GHL controller

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -90,6 +90,7 @@
 #endif
 
 #define IS_XBOXONE(xtype) ((xtype) == XTYPE_XBOXONE)
+#define IS_GHL(quirks) ((quirks) & QUIRK_GHL_XBOXONE)
 #define XPAD_PKT_LEN 64
 
 /* The Guitar Hero Live (GHL) Xbox One dongles require a poke 
@@ -2359,14 +2360,16 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
 	xpad->intf = intf;
 	xpad->mapping = xpad_device[i].mapping;
 	xpad->xtype = xpad_device[i].xtype;
-	if (IS_XBOXONE(xpad->xtype)) {
+	xpad->name = xpad_device[i].name;
+	xpad->quirks = xpad_device[i].quirks;
+	xpad->packet_type = PKT_XB;
+  
+  if (IS_XBOXONE(xpad->xtype) && !IS_GHL(xpad->quirks)) {
 	    dev_info(&intf->dev, "Blocking all Xbox One controllers\n");
 	    error = -ENODEV;
 	    goto err_free_in_urb;
 	}
-	xpad->name = xpad_device[i].name;
-	xpad->quirks = xpad_device[i].quirks;
-	xpad->packet_type = PKT_XB;
+
 	INIT_WORK(&xpad->work, xpad_presence_work);
 
 	if (xpad->xtype == XTYPE_UNKNOWN) {


### PR DESCRIPTION
Not sure whether you want it in this kernel module or whether it's better to maintain a fork, but it would be incredibly useful to me if everything was blacklisted *but* the kernel module for the GHL xbox one adapter. There's no support in xone, and it would probably be a bunch of work to implement it there. I'd like to use xone for everything else and I don't think there'd be a conflict, so I've made a PR that adds a small exception for the Guitar Hero Live controller. If this isn't something you want here, I understand if this PR is rejected.

If you could test whether everything compiles and works correctly, please do. The current unstable nixpkgs has a bug that causes a compilation error, so I need to wait for the fix to become available. Will add a comment once that resolves stating whether it all works.

Thanks!